### PR TITLE
Added Milliseconds

### DIFF
--- a/sample_app/source/tealium/tealiumBuilder.brs
+++ b/sample_app/source/tealium/tealiumBuilder.brs
@@ -22,6 +22,7 @@ function TealiumBuilder(account as String, profile as String, logLevel = 3 as In
         _logLevel: logLevel
         _environment: invalid
         _datasource: invalid
+        _epochInMilli: false
 
         _IsValidAccount: function () as Boolean
             'valid if doesn't contain empty spaces and not an empty string
@@ -74,9 +75,14 @@ function TealiumBuilder(account as String, profile as String, logLevel = 3 as In
             return m
         end function
 
+        SetEpochInMilli: function (epochInMilli as Boolean) as Object
+            m._epochInMilli = epochInMilli
+            return m
+        end function
+
         Build: function () as Object
             if m._IsValidConfig()
-                return TealiumCore(m._logLevel, m._account, m._profile, m._environment, m._datasource)
+                return TealiumCore(m._logLevel, m._account, m._profile, m._environment, m._datasource, m._epochInMilli)
             end if
             return invalid
         end function

--- a/sample_app/source/tealium/tealiumCore.brs
+++ b/sample_app/source/tealium/tealiumCore.brs
@@ -14,8 +14,8 @@
 '@param environment Tealium environment identifier as a string (required)
 '@param logLevel as an integer 0-None,1-Errors,2-Warnings,3-Messages | higher log levels include lower
 '@return Object Instance of Tealium
-function TealiumCore(logLevel as Integer, account as String, profile as String, environment=invalid, datasource=invalid) as Object
-    Instantiate = function (logLevel as Integer, account as String, profile as String, environment=invalid, datasource=invalid) as Object
+function TealiumCore(logLevel as Integer, account as String, profile as String, environment=invalid, datasource=invalid, epochInMilli=false) as Object
+    Instantiate = function (logLevel as Integer, account as String, profile as String, environment=invalid, datasource=invalid, epochInMilli=false) as Object
         return {
             'Initialize gets called in the createTealium function. Use to do any kind of setup after creating the object.
             Initialize: function () as Object
@@ -35,6 +35,7 @@ function TealiumCore(logLevel as Integer, account as String, profile as String, 
             profile: profile
             environment: environment
             datasource: datasource
+            epochInMilli: epochInMilli
 
             'Resets Session ID - if needed
             ResetSessionId: function () as Integer
@@ -168,6 +169,12 @@ function TealiumCore(logLevel as Integer, account as String, profile as String, 
                 return date
             end function
 
+            _GetTimeStampMilli: function () as String
+                now = CreateObject("roDateTime")
+                date = now.asSeconds().ToStr() + m._zpad(now.GetMilliseconds().ToStr(), 3)
+                return date
+            end function
+
             _GetUniversalDataSources: function () as Object
                 dataSources = CreateObject("roAssociativeArray")
                 dataSources.Append(m._GetPersistentData())
@@ -181,8 +188,12 @@ function TealiumCore(logLevel as Integer, account as String, profile as String, 
                 this = {
                     tealium_random : m._GetRandomNumber()
                     tealium_session_id : m.sessionId
-                    tealium_timestamp_epoch : m._GetTimeStamp()
                 }
+                if m.epochInMilli
+                    this.tealium_timestamp_epoch = m._GetTimeStampMilli()
+                else
+                    this.tealium_timestamp_epoch = m._GetTimeStamp()
+                end if
                 return this
             end function
 
@@ -258,7 +269,15 @@ function TealiumCore(logLevel as Integer, account as String, profile as String, 
                 sec.Write(key, value)
                 sec.Flush() 'commit it
             end function
+
+            _zpad: function (toPad As String, length as Integer) as String
+                paddedString = toPad
+                while Len(paddedString) < length
+                    paddedString = "0" + paddedString
+                end while
+                return paddedString
+            end function
         }
     end function
-    return Instantiate(logLevel, account, profile, environment, datasource).Initialize()
+    return Instantiate(logLevel, account, profile, environment, datasource, epochInMilli).Initialize()
 end function

--- a/sample_app/source/tests/testTealium.brs
+++ b/sample_app/source/tests/testTealium.brs
@@ -25,6 +25,7 @@ function TestTealiumHasProperties(t as Object)
         "TrackEvent"
         "toStr"
         "_tealiumLog"
+        "epochInMilli"
     ]
 
     for each prop in requiredProps
@@ -51,6 +52,7 @@ function TestTealiumHasEnvironment(t as Object)
         "TrackEvent"
         "toStr"
         "_tealiumLog"
+        "epochInMilli"
     ]
 
     for each prop in requiredProps
@@ -77,6 +79,7 @@ function TestTealiumHasDatasource(t as Object)
         "TrackEvent"
         "toStr"
         "_tealiumLog"
+        "epochInMilli"
     ]
 
     for each prop in requiredProps
@@ -249,6 +252,20 @@ function TestTealiumSetLogLevelViaConstructor(t as Object)
     for i = 0 to 3
         tealium = TealiumBuilder(testAccount, testProfile, i).Build()
         t.AssertTrue(tealium._tealiumLog.logLevelThreshold=i)
+    end for
+end function
+
+' test the "epochInMilli" function
+function TestTealiumSetsEpochInMilli(t as Object)
+    print "Entering TestTealiumSetsEpochInMilli"
+
+    testAccount = "testAccount"
+    testProfile = "testProfile"
+
+    for i = 1 to 5
+        shouldSetEpochInMilli = (i MOD 2 = 0)
+        tealium = TealiumBuilder(testAccount, testProfile).SetEpochInMilli(shouldSetEpochInMilli).Build()
+        t.AssertEqual(tealium.epochInMilli, shouldSetEpochInMilli)
     end for
 end function
 


### PR DESCRIPTION
Added allowing milliseconds for `tealium_timestamp_epoch` as an option when building Tealium as we need to match Android and iOS SDK’s which send their epochs in milliseconds

just use the `SetEpochInMilli` method.  This patch should be completely backwards compatible and should not change the API of the builder.

`TealiumBuilder("testAccount", "testProfile").SetEpochInMilli(true).Build()`